### PR TITLE
Fix: place order fails unless settings saved; add default

### DIFF
--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -87,6 +87,7 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 				'desc'     => __( 'Determine if order payments are successful when using this gateway.', 'woocommerce-gateway-dummy' ),
 				'id'       => 'woo_dummy_payment_result',
 				'type'     => 'select',
+				'default'  => 'success',
 				'options'  => array(
 					'success'  => __( 'Success', 'woocommerce-gateway-dummy' ),
 					'failure'  => __( 'Failure', 'woocommerce-gateway-dummy' ),


### PR DESCRIPTION
If you try to place an order without first visiting `wp-admin/admin.php?page=wc-settings&tab=checkout&section=dummy` and saving, the following error occurs:

> Order payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.

<img width="821" alt="Screenshot 2023-01-20 at 8 35 20 PM" src="https://user-images.githubusercontent.com/4720401/213843546-174b2920-0881-4ef9-bc65-5433facf8414.png">

To test/confirm this, delete the plugin settings, add something to cart, press "Place Order".

```
wp option delete woocommerce_dummy_settings
```

The solution is to add a default to the gateway settings: `'result'`, `'default'  => 'success',`.