### PR TITLE
Add new feature to hide if non-admin users on front end

### DIFF
--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -47,9 +47,10 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 		$this->init_settings();
 
 		// Define user set variables.
-		$this->title        = $this->get_option( 'title' );
-		$this->description  = $this->get_option( 'description' );
-		$this->instructions = $this->get_option( 'instructions', $this->description );
+		$this->title                    = $this->get_option( 'title' );
+		$this->description              = $this->get_option( 'description' );
+		$this->instructions             = $this->get_option( 'instructions', $this->description );
+		$this->hide_for_non_admin_users = $this->get_option( 'hide_for_non_admin_users' );
 
 		// Actions.
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
@@ -66,7 +67,12 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 				'title'   => __( 'Enable/Disable', 'woocommerce-gateway-dummy' ),
 				'type'    => 'checkbox',
 				'label'   => __( 'Enable Dummy Payments', 'woocommerce-gateway-dummy' ),
-				'default' => 'yes'
+				'default' => 'yes',
+			),
+			'hide_for_non_admin_users' => array(
+				'type'    => 'checkbox',
+				'label'   => __( 'Hide at checkout for non-admin users', 'woocommerce-gateway-dummy' ),
+				'default' => 'no',
 			),
 			'title' => array(
 				'title'       => __( 'Title', 'woocommerce-gateway-dummy' ),

--- a/woocommerce-gateway-dummy.php
+++ b/woocommerce-gateway-dummy.php
@@ -53,7 +53,11 @@ class WC_Dummy_Payments {
 	 * @param array
 	 */
 	public static function add_gateway( $gateways ) {
-		$gateways[] = 'WC_Gateway_Dummy';
+		$options                  = get_option( 'woocommerce_dummy_settings', array() );
+		$hide_for_non_admin_users = $options['hide_for_non_admin_users'];
+		if ( ( 'yes' === $hide_for_non_admin_users && current_user_can( 'manage_options' ) ) || 'no' === $hide_for_non_admin_users ) {
+			$gateways[] = 'WC_Gateway_Dummy';
+		}
 		return $gateways;
 	}
 

--- a/woocommerce-gateway-dummy.php
+++ b/woocommerce-gateway-dummy.php
@@ -53,8 +53,15 @@ class WC_Dummy_Payments {
 	 * @param array
 	 */
 	public static function add_gateway( $gateways ) {
-		$options                  = get_option( 'woocommerce_dummy_settings', array() );
-		$hide_for_non_admin_users = $options['hide_for_non_admin_users'];
+
+		$options = get_option( 'woocommerce_dummy_settings', array() );
+
+		if ( isset( $options['hide_for_non_admin_users'] ) ) {
+			$hide_for_non_admin_users = $options['hide_for_non_admin_users'];
+		} else {
+			$hide_for_non_admin_users = 'no';
+		}
+
 		if ( ( 'yes' === $hide_for_non_admin_users && current_user_can( 'manage_options' ) ) || 'no' === $hide_for_non_admin_users ) {
 			$gateways[] = 'WC_Gateway_Dummy';
 		}
@@ -100,7 +107,7 @@ class WC_Dummy_Payments {
 			add_action(
 				'woocommerce_blocks_payment_method_type_registration',
 				function( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
-					$payment_method_registry->register( new WC_Gateway_Dummy_Blocks_Support );
+					$payment_method_registry->register( new WC_Gateway_Dummy_Blocks_Support() );
 				}
 			);
 		}


### PR DESCRIPTION
### Changes in this Pull Request

- Add checkbox option on settings page to "Hide at checkout for non-admin users"
- Add conditional code which prevents the Dummy Gateway from showing up at checkout for non-admin users

This is to allow us to use the Dummy Gateway on a production site without affecting normal customers.
### To test

1. Leave option unchecked, verify that the Dummy Gateway shows up as an option for admin and non-admin users
2. Check the option: verify it still shows up for admin users
3. Check the option: verify it does _not_ show up for non-admin users

### Screenshots
![SCR-20230928-ipxi](https://github.com/woocommerce/woocommerce-gateway-dummy/assets/2067992/db9adbfd-dfed-49cc-9c01-d33b5a32341a)

![SCR-20230928-iqcz](https://github.com/woocommerce/woocommerce-gateway-dummy/assets/2067992/b0b9b688-91f3-4383-9a60-b48c16d4290a)


