### PR TITLE
Use class to set id, not constructor

### DIFF
--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -35,11 +35,17 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 	protected $hide_for_non_admin_users;
 
 	/**
+	 * Unique id for the gateway.
+	 * @var string
+	 *
+	 */
+	public $id = 'dummy';
+
+	/**
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {
 		
-		$this->id                 = 'dummy';
 		$this->icon               = apply_filters( 'woocommerce_dummy_gateway_icon', '' );
 		$this->has_fields         = false;
 		$this->supports           = array(


### PR DESCRIPTION
There is no benefit to setting the gateway id in the constructor.  Doing it that way makes it difficult to extend the class, particularly because the constructor uses the id to add the save action. By putting it outside the constructor, I can extend the class and change the id _before_ the class is instantiated.

https://github.com/woocommerce/woocommerce-gateway-dummy/blob/b11ad68751629d3deb2f6eb60b6acabea005b224/includes/class-wc-gateway-dummy.php#L70

This repo is used as a template for people writing gateways so changing it here should be impactful.

Required for: [BrianHenryIE/bh-wc-duplicate-payment-gateways](https://github.com/BrianHenryIE/bh-wc-duplicate-payment-gateways)
