### PR TITLE
Add Pre-orders to supported features.

### DIFF
--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -49,6 +49,7 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 		$this->icon               = apply_filters( 'woocommerce_dummy_gateway_icon', '' );
 		$this->has_fields         = false;
 		$this->supports           = array(
+			'pre-orders',
 			'products',
 			'subscriptions',
 			'subscription_cancellation',


### PR DESCRIPTION
Adds `pre-orders` to the list of supported feature to enable using the gateway when testing the Pre-orders extension.

Fixes #37 