### PR TITLE
Set order status to failed for testing failed recurring payments.

### DIFF
--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -133,10 +133,9 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 
 		$payment_result = $this->get_option( 'result' );
+		$order = wc_get_order( $order_id );
 
 		if ( 'success' === $payment_result ) {
-			$order = wc_get_order( $order_id );
-
 			$order->payment_complete();
 
 			// Remove cart
@@ -148,8 +147,7 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 				'redirect'	=> $this->get_return_url( $order )
 			);
 		} else {
-			$message = __( 'Order payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' );
-			throw new Exception( $message );
+			$order->update_status( 'failed', __( 'Subscription payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' ) );
 		}
 	}
 

--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -166,8 +166,7 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 		if ( 'success' === $payment_result ) {
 			$order->payment_complete();
 		} else {
-			$message = __( 'Order payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' );
-			throw new Exception( $message );
+			$order->update_status( 'failed', __( 'Subscription payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' ) );
 		}
 	}
 }

--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -147,7 +147,9 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 				'redirect'	=> $this->get_return_url( $order )
 			);
 		} else {
-			$order->update_status( 'failed', __( 'Subscription payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' ) );
+			$message = __( 'Order payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' );
+			$order->update_status( 'failed', $message );
+			throw new Exception( $message );
 		}
 	}
 


### PR DESCRIPTION
This sets the status of a failed recurring payment to `failed` when testing a failing gateway.

Woo Subscriptions hooks in to the status transition when the payments fail to trigger features such as the automatic retry of failed payments.

Fixes #38.