### PR TITLE
Check if not an object

### DIFF
--- a/includes/blocks/class-wc-dummy-payments-blocks.php
+++ b/includes/blocks/class-wc-dummy-payments-blocks.php
@@ -37,6 +37,9 @@ final class WC_Gateway_Dummy_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return boolean
 	 */
 	public function is_active() {
+		if( is_object( $this->gateway->is_available() ) ){
+			return false;
+		}
 		return $this->gateway->is_available();
 	}
 


### PR DESCRIPTION
A user requested an additional note due to an error that occurred during an update.