### PR TITLE
Improve Pre-order support.

### DIFF
--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -144,7 +144,7 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 					&& WC_Pre_Orders_Order::order_contains_pre_order( $order )
 					&& WC_Pre_Orders_Order::order_will_be_charged_upon_release( $order )
 			) {
-				// Mark order as pre-ordered.
+				// Mark order as tokenized.
 				$order->update_meta_data( '_wc_pre_orders_has_payment_token', '1' );
 				$order->save_meta_data();
 				WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );

--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -76,6 +76,8 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 		// Actions.
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_scheduled_subscription_payment_dummy', array( $this, 'process_subscription_payment' ), 10, 2 );
+
+		add_action ( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->id, array( $this, 'process_pre_order_release_payment' ), 10 );
 	}
 
 	/**
@@ -179,6 +181,24 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 			$order->payment_complete();
 		} else {
 			$order->update_status( 'failed', __( 'Subscription payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' ) );
+		}
+	}
+
+	/**
+	 * Process pre-order payment upon order release.
+	 *
+	 * Processes the payment for pre-orders charged upon release.
+	 *
+	 * @param WC_Order $order The order object.
+	 */
+	public function process_pre_order_release_payment( $order ) {
+		$payment_result = $this->get_option( 'result' );
+
+		if ( 'success' === $payment_result ) {
+			$order->payment_complete();
+		} else {
+			$message = __( 'Order payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' );
+			$order->update_status( 'failed', $message );
 		}
 	}
 }

--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -76,7 +76,6 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 		// Actions.
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_scheduled_subscription_payment_dummy', array( $this, 'process_subscription_payment' ), 10, 2 );
-
 		add_action ( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->id, array( $this, 'process_pre_order_release_payment' ), 10 );
 	}
 
@@ -144,7 +143,7 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 					&& WC_Pre_Orders_Order::order_contains_pre_order( $order )
 					&& WC_Pre_Orders_Order::order_will_be_charged_upon_release( $order )
 			) {
-				// Mark order as tokenized.
+				// Mark order as tokenized (no token is saved for the dummy gateway).
 				$order->update_meta_data( '_wc_pre_orders_has_payment_token', '1' );
 				$order->save_meta_data();
 				WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );


### PR DESCRIPTION
This is a follow-up to #39 in which I missed some steps adding pre-order support.

In this pull request:

* for initial orders of a pre-order product charged upon release, mark the pre-order as being tokenized
* set the order status to pre-ordered
* processes the payment of a pre-ordered product charged upon release when the pre-order is completed according to the dummy gateway settings