### PR TITLE
Add tokenization support.

### DIFF
--- a/includes/class-wc-gateway-dummy.php
+++ b/includes/class-wc-gateway-dummy.php
@@ -162,6 +162,27 @@ class WC_Gateway_Dummy extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Display the payment fields for the shortcode checkout page.
+	 *
+	 * Modifies the payment fields displayed on the checkout page to include
+	 * the any saved payment methods and the option to save a new payment method.
+	 */
+	public function payment_fields() {
+		$description = $this->get_description();
+
+		if ( $description ) {
+			// KSES is ran within get_description, but not here since there may be custom HTML returned by extensions.
+			echo wpautop( wptexturize( $description ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+
+		if ( $this->supports( 'tokenization' ) && is_checkout() ) {
+			$this->tokenization_script();
+			$this->saved_payment_methods();
+			$this->save_payment_method_checkbox();
+		}
+	}
+
+	/**
 	 * Process the payment and return the result.
 	 *
 	 * @param  int  $order_id

--- a/includes/class-wc-payment-token-dummy.php
+++ b/includes/class-wc-payment-token-dummy.php
@@ -1,0 +1,61 @@
+<?php
+
+class WC_Payment_Token_Dummy extends WC_Payment_Token {
+
+	/**
+	 * Token Type.
+	 *
+	 * @var string
+	 */
+	protected $type = 'dummy';
+
+	/**
+	 * Validate the token.
+	 *
+	 * @return bool True if token is valid.
+	 */
+	public function validate () {
+		if ( false === parent::validate() ) {
+			return false;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		$gateways = WC()->payment_gateways->payment_gateways();
+		if ( ! isset( $gateways[ 'dummy' ] ) ) {
+			return false;
+		}
+
+		$gateway = $gateways[ 'dummy' ];
+
+		if ( ! $gateway->enabled === 'yes' ) {
+			return false;
+		}
+
+		if ( ! $gateway->supports( 'tokenization' ) ) {
+			return false;
+		}
+
+		if ( $gateway->get_option( 'result' ) !== 'success' ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get display name for the token.
+	 *
+	 * @param string $deprecated
+	 * @return string Display name.
+	 */
+	public function get_display_name( $deprecated = '' ) {
+		return sprintf(
+			/* translators: %s: Payment token ID */
+			__( 'Dummy Payment Token %s', 'woocommerce-gateway-dummy' ),
+			$this->get_id() ? '#' . $this->get_id() : ''
+		);
+	}
+}

--- a/resources/js/frontend/index.js
+++ b/resources/js/frontend/index.js
@@ -12,12 +12,37 @@ const defaultLabel = __(
 );
 
 const label = decodeEntities( settings.title ) || defaultLabel;
+
 /**
  * Content component
  */
 const Content = () => {
 	return decodeEntities( settings.description || '' );
 };
+
+const SavedPaymentContent = ( props ) => {
+	const supportsTokenization = settings.supports.includes( 'tokenization' );
+
+	if ( ! supportsTokenization ) {
+		return null;
+	}
+
+	return (
+		<div style={
+			{
+				border: '1px solid #ccc',
+				borderTop: 'none',
+				padding: '1rem',
+				marginTop: '-16px',
+			}
+		}>
+			<p>
+				<small>{ __( 'For testing tokenization support', 'woocommerce-gateway-dummy' ) }</small>
+			</p>
+		</div>
+	);
+};
+
 /**
  * Label component
  *
@@ -35,11 +60,14 @@ const Dummy = {
 	name: "dummy",
 	label: <Label />,
 	content: <Content />,
+	savedTokenComponent: <SavedPaymentContent />,
 	edit: <Content />,
 	canMakePayment: () => true,
 	ariaLabel: label,
 	supports: {
 		features: settings.supports,
+		showSavedCards: true,
+		showSaveOption: true,
 	},
 };
 

--- a/woocommerce-gateway-dummy.php
+++ b/woocommerce-gateway-dummy.php
@@ -45,6 +45,8 @@ class WC_Dummy_Payments {
 		// Registers WooCommerce Blocks integration.
 		add_action( 'woocommerce_blocks_loaded', array( __CLASS__, 'woocommerce_gateway_dummy_woocommerce_block_support' ) );
 
+		// Prevent errors on My Account.
+		add_filter( 'woocommerce_saved_payment_methods_list', array( __CLASS__, 'saved_payment_methods_list' ), 20 );
 	}
 
 	/**
@@ -72,6 +74,11 @@ class WC_Dummy_Payments {
 	 * Plugin includes.
 	 */
 	public static function includes() {
+
+		// Make the WC_Payment_Token_Dummy class available.
+		if ( class_exists( 'WC_Payment_Token' ) ) {
+			require_once 'includes/class-wc-payment-token-dummy.php';
+		}
 
 		// Make the WC_Gateway_Dummy class available.
 		if ( class_exists( 'WC_Payment_Gateway' ) ) {
@@ -111,6 +118,29 @@ class WC_Dummy_Payments {
 				}
 			);
 		}
+	}
+
+	/**
+	 * Prevent errors on My Account.
+	 *
+	 * The My Account page will throw and error if the payment method does
+	 * not include a brand. This method adds a brand to the Dummy Payment Token.
+	 *
+	 * Runs on `woocommerce_saved_payment_methods_list, 20` filter.
+	 *
+	 * @param array $tokens
+	 * @return array
+	 */
+	public static function saved_payment_methods_list( $tokens ) {
+		if ( empty( $tokens['dummy'] ) ) {
+			return $tokens;
+		}
+
+		foreach ( $tokens['dummy'] as &$token ) {
+			$token['method']['brand'] = __( 'Dummy Payment Token', 'woocommerce-gateway-dummy' );
+		}
+
+		return $tokens;
 	}
 }
 


### PR DESCRIPTION
Adds tokenization support to the gateway.

This allows purchasers to save the payment method during the checkout process to generate a payment token.

I accept that it seems odd to allow for payment tokens for a gateway that doesn't require any input, the purpose is to allow the plugin to be used for testing extensions that require tokenization support. 

This will assist with writing the E2E test suite for https://github.com/woocommerce/woocommerce-deposits/issues/375

Fixes #47.

