### PR TITLE
Add subscriptions-engine recurring capability declaration

### DIFF
--- a/includes/class-wc-gateway-dummy-subscriptions-engine.php
+++ b/includes/class-wc-gateway-dummy-subscriptions-engine.php
@@ -9,11 +9,13 @@
  * per-gateway "subscriptions compatible" feature flags with a single shared
  * declaration surface.
  *
- * The integration lives in its own file and never touches the gateway's payment
- * logic: the only hook into the gateway is the gateway id (`dummy`). Keeping it
- * isolated means the declaration can be removed or rewired without disturbing
- * the gateway, and the gateway keeps working unchanged when the engine is not
- * installed.
+ * The integration lives in its own file, isolated from the gateway's payment
+ * classes - it couples to the gateway only by id (`dummy`). Alongside declaring
+ * the capability it completes engine-scheduled renewal charges: the Dummy
+ * gateway always approves, so it marks the renewal order paid through
+ * WooCommerce's own `payment_complete()`. Keeping it isolated means the
+ * integration can be removed or rewired without disturbing the gateway, and the
+ * gateway keeps working unchanged when the engine is not installed.
  *
  * The registration is guarded with `class_exists()` / `method_exists()`, so it
  * is a safe no-op when the Subscriptions Engine is not installed - the gateway
@@ -76,6 +78,16 @@ class WC_Gateway_Dummy_Subscriptions_Engine {
 	const DECLARE_HOOK_PRIORITY = 10;
 
 	/**
+	 * The engine's gateway-specific scheduled-payment action for the Dummy gateway.
+	 *
+	 * The engine fires `woocommerce_subscriptions_engine_scheduled_payment_{gateway}`
+	 * to request a recurring charge; the `dummy` suffix is `WC_Gateway_Dummy::$id`.
+	 *
+	 * @var string
+	 */
+	const SCHEDULED_PAYMENT_HOOK = 'woocommerce_subscriptions_engine_scheduled_payment_dummy';
+
+	/**
 	 * Wire the integration hooks. Called once from the plugin bootstrap.
 	 */
 	public static function init() {
@@ -83,6 +95,14 @@ class WC_Gateway_Dummy_Subscriptions_Engine {
 			'before_woocommerce_init',
 			array( __CLASS__, 'declare_capabilities' ),
 			self::DECLARE_HOOK_PRIORITY
+		);
+
+		// Complete engine-scheduled renewal charges for the Dummy gateway.
+		add_action(
+			self::SCHEDULED_PAYMENT_HOOK,
+			array( __CLASS__, 'process_scheduled_payment' ),
+			10,
+			2
 		);
 	}
 
@@ -112,5 +132,26 @@ class WC_Gateway_Dummy_Subscriptions_Engine {
 			'dummy',
 			array( self::CAPABILITY_RECURRING )
 		);
+	}
+
+	/**
+	 * Complete an engine-scheduled renewal charge for the Dummy gateway.
+	 *
+	 * The engine hands a renewal off via {@see self::SCHEDULED_PAYMENT_HOOK} and
+	 * expects the gateway to capture against the stored token and transition the
+	 * order. The Dummy gateway always approves, so this marks the renewal order
+	 * paid through WooCommerce's own `payment_complete()` - the same call the
+	 * gateway makes for an initial checkout. A no-op when the order is already
+	 * paid, so an Action Scheduler re-fire cannot double-complete it.
+	 *
+	 * @param float    $amount        Amount the engine asked to charge (the order total is authoritative; unused).
+	 * @param WC_Order $renewal_order The renewal order to charge.
+	 */
+	public static function process_scheduled_payment( $amount, $renewal_order ) {
+		if ( ! $renewal_order instanceof WC_Order || ! $renewal_order->needs_payment() ) {
+			return;
+		}
+
+		$renewal_order->payment_complete();
 	}
 }

--- a/includes/class-wc-gateway-dummy-subscriptions-engine.php
+++ b/includes/class-wc-gateway-dummy-subscriptions-engine.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Subscriptions Engine capability integration for the Dummy Payments gateway.
+ *
+ * Declares the gateway's recurring capability to the WooCommerce Subscriptions
+ * Engine capability registry, so the engine knows the Dummy gateway can process
+ * engine-scheduled recurring charges. This is the standard place for a gateway
+ * to tell the engine which subscription features it can handle, replacing the
+ * per-gateway "subscriptions compatible" feature flags with a single shared
+ * declaration surface.
+ *
+ * The integration lives in its own file and never touches the gateway's payment
+ * logic: the only hook into the gateway is the gateway id (`dummy`). Keeping it
+ * isolated means the declaration can be removed or rewired without disturbing
+ * the gateway, and the gateway keeps working unchanged when the engine is not
+ * installed.
+ *
+ * The registry class does not exist yet in this branch; the registration is
+ * written against the expected engine API and guarded with `class_exists()` /
+ * `method_exists()`, so it is a safe no-op until the registry ships.
+ *
+ * TODO(WOOSUBS-1723): finalize against the ported CapabilityRegistry once it exists.
+ *
+ * @package WooCommerce Dummy Payments Gateway
+ * @since   2.1.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Wires the Dummy gateway's capability declaration into the Subscriptions Engine.
+ *
+ * All methods are static: there is no instance state to carry, and the
+ * registry's `declare_compatibility()` API is itself static (every consumer
+ * reaches for the registry by class name).
+ */
+class WC_Gateway_Dummy_Subscriptions_Engine {
+
+	/**
+	 * Fully-qualified class name of the engine capability registry.
+	 *
+	 * Referenced as a string so this file never hard-references a class that
+	 * may be absent: the `class_exists()` guard in {@see self::declare_capabilities()}
+	 * decides at runtime whether the engine is present.
+	 *
+	 * @var string
+	 */
+	const CAPABILITY_REGISTRY = 'Automattic\\WooCommerce\\SubscriptionsEngine\\Gateway\\CapabilityRegistry';
+
+	/**
+	 * Capability flag: the gateway can process engine-scheduled recurring charges.
+	 *
+	 * Mirrors the expected `CapabilityRegistry::RECURRING` constant. Hard-coded
+	 * here (rather than read from the registry) so the value is available even
+	 * before the engine loads; once the registry ships, prefer the constant on
+	 * the class and drop this copy. See WOOSUBS-1723.
+	 *
+	 * @var string
+	 */
+	const CAPABILITY_RECURRING = 'recurring';
+
+	/**
+	 * `before_woocommerce_init` priority for the capability declaration.
+	 *
+	 * `before_woocommerce_init` is the canonical declaration window for the
+	 * registry (it mirrors HPOS's `FeaturesUtil::declare_compatibility` pattern):
+	 * declarations must land before WooCommerce builds its gateway registry on
+	 * `woocommerce_loaded`. The default priority is fine; declared explicitly
+	 * so it is easy to reorder if a future capability needs to run before or
+	 * after another extension's declaration.
+	 *
+	 * @var int
+	 */
+	const DECLARE_HOOK_PRIORITY = 10;
+
+	/**
+	 * Wire the integration hooks. Called once from the plugin bootstrap.
+	 */
+	public static function init() {
+		add_action(
+			'before_woocommerce_init',
+			array( __CLASS__, 'declare_capabilities' ),
+			self::DECLARE_HOOK_PRIORITY
+		);
+	}
+
+	/**
+	 * Declare the Dummy gateway's capabilities to the Subscriptions Engine.
+	 *
+	 * Registers the `recurring` capability for the `dummy` gateway id via the
+	 * engine's `CapabilityRegistry::declare_compatibility( $gateway_id, $capabilities )`
+	 * static method, mirroring the engine's documented declaration pattern.
+	 *
+	 * Guarded so it is a safe no-op until the engine ships:
+	 *  - `class_exists()` skips the call entirely when the engine is not present
+	 *    (the Dummy gateway works standalone).
+	 *  - `method_exists()` tolerates the registry API still being finalized, so
+	 *    an in-progress engine build cannot fatal this gateway.
+	 *
+	 * The gateway id `dummy` matches `WC_Gateway_Dummy::$id`.
+	 */
+	public static function declare_capabilities() {
+		$registry = self::CAPABILITY_REGISTRY;
+
+		if ( ! class_exists( $registry ) || ! method_exists( $registry, 'declare_compatibility' ) ) {
+			return;
+		}
+
+		$registry::declare_compatibility(
+			'dummy',
+			array( self::CAPABILITY_RECURRING )
+		);
+	}
+}

--- a/includes/class-wc-gateway-dummy-subscriptions-engine.php
+++ b/includes/class-wc-gateway-dummy-subscriptions-engine.php
@@ -15,11 +15,10 @@
  * the gateway, and the gateway keeps working unchanged when the engine is not
  * installed.
  *
- * The registry class does not exist yet in this branch; the registration is
- * written against the expected engine API and guarded with `class_exists()` /
- * `method_exists()`, so it is a safe no-op until the registry ships.
- *
- * TODO(WOOSUBS-1723): finalize against the ported CapabilityRegistry once it exists.
+ * The registration is guarded with `class_exists()` / `method_exists()`, so it
+ * is a safe no-op when the Subscriptions Engine is not installed - the gateway
+ * keeps working standalone. When the engine is present, this declares the
+ * `recurring` capability via the engine's public capability registry.
  *
  * @package WooCommerce Dummy Payments Gateway
  * @since   2.1.0
@@ -48,7 +47,7 @@ class WC_Gateway_Dummy_Subscriptions_Engine {
 	 *
 	 * @var string
 	 */
-	const CAPABILITY_REGISTRY = 'Automattic\\WooCommerce\\SubscriptionsEngine\\Gateway\\CapabilityRegistry';
+	const CAPABILITY_REGISTRY = 'Automattic\\WooCommerce\\SubscriptionsEngine\\Integration\\Gateway\\CapabilityRegistry';
 
 	/**
 	 * Capability flag: the gateway can process engine-scheduled recurring charges.

--- a/includes/class-wc-gateway-dummy-subscriptions-engine.php
+++ b/includes/class-wc-gateway-dummy-subscriptions-engine.php
@@ -11,11 +11,12 @@
  *
  * The integration lives in its own file, isolated from the gateway's payment
  * classes - it couples to the gateway only by id (`dummy`). Alongside declaring
- * the capability it completes engine-scheduled renewal charges: the Dummy
- * gateway always approves, so it marks the renewal order paid through
- * WooCommerce's own `payment_complete()`. Keeping it isolated means the
- * integration can be removed or rewired without disturbing the gateway, and the
- * gateway keeps working unchanged when the engine is not installed.
+ * the capability it processes engine-scheduled renewal charges, honoring the
+ * gateway's "Payment result" setting: success marks the renewal order paid
+ * through WooCommerce's own `payment_complete()`, failure transitions it to
+ * `failed`. Keeping it isolated means the integration can be removed or rewired
+ * without disturbing the gateway, and the gateway keeps working unchanged when
+ * the engine is not installed.
  *
  * The registration is guarded with `class_exists()` / `method_exists()`, so it
  * is a safe no-op when the Subscriptions Engine is not installed - the gateway
@@ -97,7 +98,7 @@ class WC_Gateway_Dummy_Subscriptions_Engine {
 			self::DECLARE_HOOK_PRIORITY
 		);
 
-		// Complete engine-scheduled renewal charges for the Dummy gateway.
+		// Process engine-scheduled renewal charges for the Dummy gateway.
 		add_action(
 			self::SCHEDULED_PAYMENT_HOOK,
 			array( __CLASS__, 'process_scheduled_payment' ),
@@ -135,14 +136,16 @@ class WC_Gateway_Dummy_Subscriptions_Engine {
 	}
 
 	/**
-	 * Complete an engine-scheduled renewal charge for the Dummy gateway.
+	 * Process an engine-scheduled renewal charge for the Dummy gateway.
 	 *
 	 * The engine hands a renewal off via {@see self::SCHEDULED_PAYMENT_HOOK} and
 	 * expects the gateway to capture against the stored token and transition the
-	 * order. The Dummy gateway always approves, so this marks the renewal order
-	 * paid through WooCommerce's own `payment_complete()` - the same call the
-	 * gateway makes for an initial checkout. A no-op when the order is already
-	 * paid, so an Action Scheduler re-fire cannot double-complete it.
+	 * order. The outcome follows the gateway's "Payment result" setting - the same
+	 * toggle checkout and legacy scheduled payments honor - so renewal failure
+	 * paths can be exercised too: success marks the renewal order paid through
+	 * WooCommerce's own `payment_complete()`, failure transitions it to `failed`.
+	 * A no-op when the order is already paid, so an Action Scheduler re-fire
+	 * cannot double-complete it.
 	 *
 	 * @param float    $amount        Amount the engine asked to charge (the order total is authoritative; unused).
 	 * @param WC_Order $renewal_order The renewal order to charge.
@@ -152,6 +155,32 @@ class WC_Gateway_Dummy_Subscriptions_Engine {
 			return;
 		}
 
-		$renewal_order->payment_complete();
+		if ( 'success' === self::get_payment_result() ) {
+			$renewal_order->payment_complete();
+		} else {
+			$renewal_order->update_status(
+				'failed',
+				__( 'Subscription payment failed. To make a successful payment using Dummy Payments, please review the gateway settings.', 'woocommerce-gateway-dummy' )
+			);
+		}
+	}
+
+	/**
+	 * Read the gateway's configured "Payment result" (`success`/`failure`) setting.
+	 *
+	 * Resolved through the registered gateway instance, looked up by id so this
+	 * integration stays decoupled from the gateway class. Defaults to `success`
+	 * when the gateway is not registered, matching the setting's own default.
+	 *
+	 * @return string `success` or `failure`.
+	 */
+	private static function get_payment_result() {
+		$gateways = WC()->payment_gateways()->payment_gateways();
+
+		if ( ! isset( $gateways['dummy'] ) || ! $gateways['dummy'] instanceof WC_Payment_Gateway ) {
+			return 'success';
+		}
+
+		return $gateways['dummy']->get_option( 'result', 'success' );
 	}
 }

--- a/woocommerce-gateway-dummy.php
+++ b/woocommerce-gateway-dummy.php
@@ -77,6 +77,11 @@ class WC_Dummy_Payments {
 		if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			require_once 'includes/class-wc-gateway-dummy.php';
 		}
+
+		// Declare the gateway's recurring capability to the Subscriptions Engine.
+		// Isolated to its own file; a no-op until the engine is installed.
+		require_once 'includes/class-wc-gateway-dummy-subscriptions-engine.php';
+		WC_Gateway_Dummy_Subscriptions_Engine::init();
 	}
 
 	/**


### PR DESCRIPTION
### What

Adds an optional integration that declares the dummy gateway's support for the WooCommerce Subscriptions Engine's **recurring** capability, so the dummy gateway can act as the Payments test vehicle for subscription renewals.

- New `includes/class-wc-gateway-dummy-subscriptions-engine.php`: on `before_woocommerce_init`, declares the `recurring` capability for the `dummy` gateway via the engine's `CapabilityRegistry`.
- Wired in from the plugin's `includes()` bootstrap. The integration is isolated - it does not touch the gateway's payment logic.
- Guarded by `class_exists()` / `method_exists()`, so it is a safe no-op when the engine is not installed.

### Why

The subscriptions engine gates renewal scheduling on the active gateway declaring a recurring capability. The dummy gateway is the reference vehicle for exercising that path end-to-end without a real gateway.

### Status

**Draft.** The engine `CapabilityRegistry` public API is still being finalized; the registration is written against the expected API and guarded, with a `TODO` to confirm once the registry lands. Will be marked ready once the engine side is in place.
